### PR TITLE
add support to extra date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ If you stopped the container, you can continue from the exact place you stopped,
 
 ## Changelog:
 
+- **0.1.2**:
+  - Support another date format for `security_alerts`.
 - **0.1.1**:
   - Bug fix for `security_alerts` task fails on second cycle.
 - **0.1.0**:

--- a/src/api.py
+++ b/src/api.py
@@ -102,7 +102,7 @@ class Api(ABC):
     def get_start_date_filter(self) -> str:
         if self._current_data_last_date is not None:
             start_date_str = self._get_new_start_date()
-            new_start_date = start_date_str.split('.')[0]
+            new_start_date = start_date_str.split('.')[0].split('+')[0]  # cut out milliseconds and timezone
             new_start_date += 'Z' if not new_start_date.endswith('Z') else ''
         else:
             start_date = datetime.utcnow() - timedelta(days=self.base_data.settings.days_back_to_fetch)


### PR DESCRIPTION
- Add support for dates that end with a timeZone (to match Azure required date format `yyyy-mm-ddThh:mm:ss('.'s+)?(zzzzzz)?`)
- Update README