### PR TITLE
support HTML encoded date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ If you stopped the container, you can continue from the exact place you stopped,
 
 ## Changelog:
 
+- **0.1.3**:
+  - Support another date format for `azure_graph`.
 - **0.1.2**:
   - Support another date format for `security_alerts`.
 - **0.1.1**:

--- a/src/api.py
+++ b/src/api.py
@@ -100,9 +100,11 @@ class Api(ABC):
         return True
 
     def get_start_date_filter(self) -> str:
-        if self._current_data_last_date is not None:
+        if self._current_data_last_date:
             start_date_str = self._get_new_start_date()
             new_start_date = start_date_str.split('.')[0].split('+')[0]  # cut out milliseconds and timezone
+            if new_start_date == start_date_str:
+                new_start_date = start_date_str.split('%2E')[0].split('%2B')[0]
             new_start_date += 'Z' if not new_start_date.endswith('Z') else ''
         else:
             start_date = datetime.utcnow() - timedelta(days=self.base_data.settings.days_back_to_fetch)

--- a/src/api.py
+++ b/src/api.py
@@ -101,17 +101,17 @@ class Api(ABC):
 
     def get_start_date_filter(self) -> str:
         if self._current_data_last_date:
-            start_date_str = self._get_new_start_date()
-            new_start_date = start_date_str.split('.')[0].split('+')[0]  # cut out milliseconds and timezone
-            if new_start_date == start_date_str:
-                new_start_date = start_date_str.split('%2E')[0].split('%2B')[0]
-            new_start_date += 'Z' if not new_start_date.endswith('Z') else ''
+            raw_new_start_date = self._get_new_start_date()
+            formatted_new_start_date = raw_new_start_date.split('.')[0].split('+')[0]  # cut out milliseconds and timezone
+            if formatted_new_start_date == raw_new_start_date:
+                formatted_new_start_date = raw_new_start_date.split('%2E')[0].split('%2B')[0]  # Support HTML encoded dates
+            formatted_new_start_date += 'Z' if not formatted_new_start_date.endswith('Z') else ''
         else:
-            start_date = datetime.utcnow() - timedelta(days=self.base_data.settings.days_back_to_fetch)
-            new_start_date = start_date.isoformat(' ', 'seconds')
-            new_start_date = new_start_date.replace(' ', 'T')
-            new_start_date += 'Z'
-        return new_start_date
+            raw_new_start_date = datetime.utcnow() - timedelta(days=self.base_data.settings.days_back_to_fetch)
+            formatted_new_start_date = raw_new_start_date.isoformat(' ', 'seconds')
+            formatted_new_start_date = formatted_new_start_date.replace(' ', 'T')
+            formatted_new_start_date += 'Z'
+        return formatted_new_start_date
 
     def _get_new_start_date(self) -> str:
         new_start_date = str(parser.parse(self._current_data_last_date) + timedelta(seconds=1))


### PR DESCRIPTION
- Following issue with azure graph date format, we need to support HTML encoded dates;
  - when doing `.split('.')[0].split('+')[0]` if it made no difference >> attempt to split with the characters HTML codes: `split('%2E')[0].split('%2B')[0]`
- update readme