### PR TITLE
Fix mail report example url

### DIFF
--- a/src/apis/azure/README.MD
+++ b/src/apis/azure/README.MD
@@ -64,7 +64,7 @@ apis:
     azure_ad_client_id: <<AZURE_AD_CLIENT_ID>>
     azure_ad_secret_value: <<AZURE_AD_SECRET_VALUE>>
     data_request:
-      url: https://login.microsoftonline.com/<<AZURE_AD_TENANT_ID>>/oauth2/v2.0/token
+      url: https://reports.office365.com/ecp/reportingwebservice/reporting.svc/MessageTrace
       additional_fields:
         type: azure_mail_reports
     scrape_interval: 60  # for mail reports we suggest no less than 60 minutes


### PR DESCRIPTION
The URL in the example shows the wrong URL to use, fixed to the correct URL for the request.