### PR TITLE
[Bug] fix `cloudflare_logs` additional URL params encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ docker stop -t 30 logzio-api-fetcher
 ```
 
 ## Changelog:
+- **2.1.1**:
+  - Bug fix for `cloudflare_logs` API type: URLs with additional query parameters (e.g., `fields=`) were being corrupted.
 - **2.1.0**:
   - Add `cloudflare_logs` type to support Cloudflare Logs Received endpoint (`/zones/{zone_id}/logs/received`) with dynamic `start`/`end` time window management and NDJSON response parsing.
 - **2.0.1**:

--- a/src/apis/cloudflare_logs/CloudflareLogs.py
+++ b/src/apis/cloudflare_logs/CloudflareLogs.py
@@ -3,7 +3,6 @@ import json
 import logging
 from pydantic import Field
 from typing import Optional
-from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 
 from src.apis.general.Api import ApiFetcher
 
@@ -29,7 +28,6 @@ class CloudflareLogs(ApiFetcher):
     days_back_fetch: int = Field(default=1, frozen=True, ge=1, le=7)
 
     next_start_time: Optional[datetime] = Field(default=None, init=False, init_var=True)
-    base_url: str = Field(default="", init=False, init_var=True)
 
     def __init__(self, **data):
         headers = {
@@ -40,30 +38,15 @@ class CloudflareLogs(ApiFetcher):
         super().__init__(headers=headers, **data)
 
         self.url = self.url.replace("{account_id}", self.cloudflare_account_id)
-
-        self.base_url = self._strip_time_params(self.url)
-
         self.next_start_time = datetime.now(timezone.utc) - timedelta(days=self.days_back_fetch)
 
     @staticmethod
-    def _strip_time_params(url):
-        """Remove start and end query parameters from the URL to get the base URL."""
-        parsed = urlparse(url)
-        params = parse_qs(parsed.query, keep_blank_values=True)
-        params.pop("start", None)
-        params.pop("end", None)
-        clean_query = urlencode(params, doseq=True)
-        return urlunparse(parsed._replace(query=clean_query))
-
-    def _build_url(self, start, end):
+    def _build_url(base_url, start, end):
         """Build the full URL with start and end parameters."""
-        separator = "&" if "?" in self.base_url and self.base_url.split("?")[1] else "?"
-        # If base_url ends with '?' or has no query string, use '?'
-        if "?" not in self.base_url:
-            separator = "?"
+        separator = "&" if "?" in base_url else "?"
         start_str = start.strftime(DATE_FORMAT)
         end_str = end.strftime(DATE_FORMAT)
-        return f"{self.base_url}{separator}start={start_str}&end={end_str}"
+        return f"{base_url}{separator}start={start_str}&end={end_str}"
 
     @staticmethod
     def _parse_ndjson(text):
@@ -93,12 +76,13 @@ class CloudflareLogs(ApiFetcher):
                          f"end limit: {end_limit.strftime(DATE_FORMAT)}")
             return all_responses
 
+        original_url = self.url
         start = self.next_start_time
 
         while start < end_limit:
             end = min(start + MAX_WINDOW, end_limit)
 
-            self.url = self._build_url(start, end)
+            self.url = self._build_url(original_url, start, end)
             logger.debug(f"Fetching {self.name} logs window: {start.strftime(DATE_FORMAT)} -> {end.strftime(DATE_FORMAT)}")
 
             response = self._make_call()
@@ -120,5 +104,6 @@ class CloudflareLogs(ApiFetcher):
             all_responses.extend(logs)
             start = end
 
+        self.url = original_url
         self.next_start_time = start
         return all_responses

--- a/tests/UnitTests/test_cloudflare_api.py
+++ b/tests/UnitTests/test_cloudflare_api.py
@@ -92,15 +92,6 @@ class TestCloudflareLogsApi(unittest.TestCase):
         """The logs/received endpoint should never get a 'since' parameter."""
         a = self._create_instance()
         self.assertNotIn("since=", a.url)
-        self.assertNotIn("since=", a.base_url)
-
-    def test_strips_start_end_from_user_url(self):
-        """If the user provides start/end in URL, they should be stripped for the base URL."""
-        a = self._create_instance(
-            url=f"{self.BASE_URL}?start=2026-02-23T10:00:00Z&end=2026-02-23T10:01:00Z"
-        )
-        self.assertNotIn("start=", a.base_url)
-        self.assertNotIn("end=", a.base_url)
 
     def test_auth_header(self):
         a = self._create_instance()
@@ -122,21 +113,20 @@ class TestCloudflareLogsApi(unittest.TestCase):
         self.assertEqual(len(logs), 2)
 
     def test_build_url(self):
-        a = self._create_instance()
         start = datetime(2026, 2, 23, 10, 0, 0, tzinfo=timezone.utc)
         end = datetime(2026, 2, 23, 11, 0, 0, tzinfo=timezone.utc)
-        url = a._build_url(start, end)
+        url = CloudflareLogs._build_url(self.BASE_URL, start, end)
         self.assertIn("start=2026-02-23T10:00:00Z", url)
         self.assertIn("end=2026-02-23T11:00:00Z", url)
         self.assertTrue(url.startswith(self.BASE_URL))
 
     def test_build_url_with_existing_params(self):
         """If base URL has other params (e.g., fields=), start/end should be appended with &."""
-        a = self._create_instance(url=f"{self.BASE_URL}?fields=ClientIP,RayID")
+        base_url = f"{self.BASE_URL}?fields=ClientIP,RayID"
         start = datetime(2026, 2, 23, 10, 0, 0, tzinfo=timezone.utc)
         end = datetime(2026, 2, 23, 11, 0, 0, tzinfo=timezone.utc)
-        url = a._build_url(start, end)
-        self.assertIn("fields=ClientIP%2CRayID", url)
+        url = CloudflareLogs._build_url(base_url, start, end)
+        self.assertIn("fields=ClientIP,RayID", url)
         self.assertIn("&start=2026-02-23T10:00:00Z", url)
         self.assertIn("&end=2026-02-23T11:00:00Z", url)
 


### PR DESCRIPTION
## Description 

- remove `_strip_time_params` method that was acting as extra safetguard against accepting time fields to the base url.
  - It's not required, since it's documented to not include `start`/`end` in the URL config, and no other API type has it. 
  - It was doing an extra url encode which seems to cause the bug 
- remove `base_url` internal field, redundant copy of `self.url`. Instead, , `send_request` now saves the original URL in a local variable before the windowed-fetch loop and restores it after.
- simplified `_build_url`
- aligned tests

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
