### PR TITLE
[Bug] fix concurrent task issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ docker stop -t 30 logzio-api-fetcher
 ```
 
 ## Changelog:
+- **2.1.2**:
+  - Bug fix: Prevent concurrent task execution when a previous task is still running, which could cause duplicate data and corrupted URLs for long-running APIs.
 - **2.1.1**:
   - Bug fix for `cloudflare_logs` API type: URLs with additional query parameters (e.g., `fields=`) were being corrupted.
 - **2.1.0**:

--- a/src/manager/TaskManager.py
+++ b/src/manager/TaskManager.py
@@ -65,6 +65,7 @@ class TaskManager:
             logger.debug(f"Starting thread to collect logs from {api.name}")
             thread = threading.Thread(target=self._run_api_task, args=(api,))
             thread.start()
+            thread.join()
 
             # Enforce new task to run every scrape_interval
             if self.event.wait(timeout=api.scrape_interval_minutes * 60):


### PR DESCRIPTION
## Description 

- prevent concurrent task execution when a previous task is still running, which could cause duplicate data and corrupted URLs for long-running APIs.
- update changelog

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
